### PR TITLE
Fixing usage of incorrect encoding for file system paths.

### DIFF
--- a/Common/Examples/DefaultExamples/Examples/AnatomyExample.m
+++ b/Common/Examples/DefaultExamples/Examples/AnatomyExample.m
@@ -32,7 +32,7 @@
      */
     
     /* Create a new workbook. */
-    lxw_workbook  *workbook   = new_workbook([self.outputFilePath cStringUsingEncoding:NSUTF8StringEncoding]);
+    lxw_workbook  *workbook   = new_workbook([self.outputFilePath fileSystemRepresentation]);
     
     /* Add a worksheet with a user defined sheet name. */
     lxw_worksheet *worksheet1 = workbook_add_worksheet(workbook, "Demo");

--- a/Common/Examples/DefaultExamples/Examples/ArrayFormulaExample.m
+++ b/Common/Examples/DefaultExamples/Examples/ArrayFormulaExample.m
@@ -33,7 +33,7 @@
      */
     
     /* Create a new workbook and add a worksheet. */
-    lxw_workbook  *workbook  = new_workbook([self.outputFilePath cStringUsingEncoding:NSUTF8StringEncoding]);
+    lxw_workbook  *workbook  = new_workbook([self.outputFilePath fileSystemRepresentation]);
     lxw_worksheet *worksheet = workbook_add_worksheet(workbook, NULL);
     
     /* Write some data for the formulas. */

--- a/Common/Examples/DefaultExamples/Examples/AutofilterExample.m
+++ b/Common/Examples/DefaultExamples/Examples/AutofilterExample.m
@@ -32,7 +32,7 @@
      *
      */
     
-    lxw_workbook  *workbook  = new_workbook([self.outputFilePath cStringUsingEncoding:NSUTF8StringEncoding]);
+    lxw_workbook  *workbook  = new_workbook([self.outputFilePath fileSystemRepresentation]);
     lxw_worksheet *worksheet = workbook_add_worksheet(workbook, NULL);
     uint16_t i;
     

--- a/Common/Examples/DefaultExamples/Examples/ConstantMemoryExample.m
+++ b/Common/Examples/DefaultExamples/Examples/ConstantMemoryExample.m
@@ -34,7 +34,7 @@
     options.constant_memory = 1;
     
     /* Create a new workbook with options. */
-    lxw_workbook  *workbook  = new_workbook_opt([self.outputFilePath cStringUsingEncoding:NSUTF8StringEncoding], &options);
+    lxw_workbook  *workbook  = new_workbook_opt([self.outputFilePath fileSystemRepresentation], &options);
     lxw_worksheet *worksheet = workbook_add_worksheet(workbook, NULL);
     
     for (row = 0; row < max_row; row++) {

--- a/Common/Examples/DefaultExamples/Examples/DatesAndTimes1Example.m
+++ b/Common/Examples/DefaultExamples/Examples/DatesAndTimes1Example.m
@@ -40,7 +40,7 @@
     double number = 41333.5;
     
     /* Create a new workbook and add a worksheet. */
-    lxw_workbook  *workbook  = new_workbook([self.outputFilePath cStringUsingEncoding:NSUTF8StringEncoding]);
+    lxw_workbook  *workbook  = new_workbook([self.outputFilePath fileSystemRepresentation]);
     lxw_worksheet *worksheet = workbook_add_worksheet(workbook, NULL);
     
     /* Add a format with date formatting. */

--- a/Common/Examples/DefaultExamples/Examples/DatesAndTimes2Example.m
+++ b/Common/Examples/DefaultExamples/Examples/DatesAndTimes2Example.m
@@ -36,7 +36,7 @@
     lxw_datetime datetime = {2013, 2, 28, 12, 0, 0.0};
     
     /* Create a new workbook and add a worksheet. */
-    lxw_workbook  *workbook  = new_workbook([self.outputFilePath cStringUsingEncoding:NSUTF8StringEncoding]);
+    lxw_workbook  *workbook  = new_workbook([self.outputFilePath fileSystemRepresentation]);
     lxw_worksheet *worksheet = workbook_add_worksheet(workbook, NULL);
     
     /* Add a format with date formatting. */

--- a/Common/Examples/DefaultExamples/Examples/DatesAndTimes3Example.m
+++ b/Common/Examples/DefaultExamples/Examples/DatesAndTimes3Example.m
@@ -58,7 +58,7 @@
     };
     
     /* Create a new workbook and add a worksheet. */
-    lxw_workbook  *workbook  = new_workbook([self.outputFilePath cStringUsingEncoding:NSUTF8StringEncoding]);
+    lxw_workbook  *workbook  = new_workbook([self.outputFilePath fileSystemRepresentation]);
     lxw_worksheet *worksheet = workbook_add_worksheet(workbook, NULL);
     
     /* Add a bold format. */

--- a/Common/Examples/DefaultExamples/Examples/DefinedNameExample.m
+++ b/Common/Examples/DefaultExamples/Examples/DefinedNameExample.m
@@ -33,7 +33,7 @@
      *
      */
     
-    lxw_workbook  *workbook   = new_workbook([self.outputFilePath cStringUsingEncoding:NSUTF8StringEncoding]);
+    lxw_workbook  *workbook   = new_workbook([self.outputFilePath fileSystemRepresentation]);
     lxw_worksheet *worksheet;
     
     /* We don't use the returned worksheets in this example and use a generic

--- a/Common/Examples/DefaultExamples/Examples/DemoExample.m
+++ b/Common/Examples/DefaultExamples/Examples/DemoExample.m
@@ -32,7 +32,7 @@
      */
     
     /* Create a new workbook and add a worksheet. */
-    lxw_workbook  *workbook  = new_workbook([self.outputFilePath cStringUsingEncoding:NSUTF8StringEncoding]);
+    lxw_workbook  *workbook  = new_workbook([self.outputFilePath fileSystemRepresentation]);
     lxw_worksheet *worksheet = workbook_add_worksheet(workbook, NULL);
     
     /* Add a format. */

--- a/Common/Examples/DefaultExamples/Examples/DocPropertiesExample.m
+++ b/Common/Examples/DefaultExamples/Examples/DocPropertiesExample.m
@@ -32,7 +32,7 @@
 	 *
 	 */
 
-	lxw_workbook       *workbook   = workbook_new([self.outputFilePath cStringUsingEncoding:NSUTF8StringEncoding]);
+	lxw_workbook       *workbook   = workbook_new([self.outputFilePath fileSystemRepresentation]);
 	lxw_worksheet      *worksheet  = workbook_add_worksheet(workbook, NULL);
 
 	/* Create a properties structure and set some of the fields. */

--- a/Common/Examples/DefaultExamples/Examples/FormatFontExample.m
+++ b/Common/Examples/DefaultExamples/Examples/FormatFontExample.m
@@ -33,7 +33,7 @@
      */
     
     /* Create a new workbook. */
-    lxw_workbook  *workbook  = new_workbook([self.outputFilePath cStringUsingEncoding:NSUTF8StringEncoding]);
+    lxw_workbook  *workbook  = new_workbook([self.outputFilePath fileSystemRepresentation]);
     
     /* Add a worksheet. */
     lxw_worksheet *worksheet = workbook_add_worksheet(workbook, NULL);

--- a/Common/Examples/DefaultExamples/Examples/FormatNumFormatExample.m
+++ b/Common/Examples/DefaultExamples/Examples/FormatNumFormatExample.m
@@ -33,7 +33,7 @@
      */
     
     /* Create a new workbook and add a worksheet. */
-    lxw_workbook  *workbook  = new_workbook([self.outputFilePath cStringUsingEncoding:NSUTF8StringEncoding]);
+    lxw_workbook  *workbook  = new_workbook([self.outputFilePath fileSystemRepresentation]);
     lxw_worksheet *worksheet = workbook_add_worksheet(workbook, NULL);
     
     /* Widen the first column to make the text clearer. */

--- a/Common/Examples/DefaultExamples/Examples/HeadersFootersExample.m
+++ b/Common/Examples/DefaultExamples/Examples/HeadersFootersExample.m
@@ -56,7 +56,7 @@
      *
      */
     
-    lxw_workbook *workbook  = new_workbook([self.outputFilePath cStringUsingEncoding:NSUTF8StringEncoding]);
+    lxw_workbook *workbook  = new_workbook([self.outputFilePath fileSystemRepresentation]);
     
     char preview[] = "Select Print Preview to see the header and footer";
     

--- a/Common/Examples/DefaultExamples/Examples/HelloExample.m
+++ b/Common/Examples/DefaultExamples/Examples/HelloExample.m
@@ -31,7 +31,7 @@
      *
      */
     
-    lxw_workbook  *workbook  = new_workbook([self.outputFilePath cStringUsingEncoding:NSUTF8StringEncoding]);
+    lxw_workbook  *workbook  = new_workbook([self.outputFilePath fileSystemRepresentation]);
     lxw_worksheet *worksheet = workbook_add_worksheet(workbook, NULL);
     
     worksheet_write_string(worksheet, 0, 0, "Hello", NULL);

--- a/Common/Examples/DefaultExamples/Examples/HideRowColExample.m
+++ b/Common/Examples/DefaultExamples/Examples/HideRowColExample.m
@@ -36,7 +36,7 @@
 	 */
 
 	/* Create a new workbook and add a worksheet. */
-	lxw_workbook  *workbook  = workbook_new([self.outputFilePath cStringUsingEncoding:NSUTF8StringEncoding]);
+	lxw_workbook  *workbook  = workbook_new([self.outputFilePath fileSystemRepresentation]);
 	lxw_worksheet *worksheet = workbook_add_worksheet(workbook, NULL);
 	lxw_row_t row;
 

--- a/Common/Examples/DefaultExamples/Examples/HideSheetExample.m
+++ b/Common/Examples/DefaultExamples/Examples/HideSheetExample.m
@@ -31,7 +31,7 @@
 	 *
 	 */
 
-	lxw_workbook  *workbook   = workbook_new([self.outputFilePath cStringUsingEncoding:NSUTF8StringEncoding]);
+	lxw_workbook  *workbook   = workbook_new([self.outputFilePath fileSystemRepresentation]);
 	lxw_worksheet *worksheet1 = workbook_add_worksheet(workbook, NULL);
 	lxw_worksheet *worksheet2 = workbook_add_worksheet(workbook, NULL);
 	lxw_worksheet *worksheet3 = workbook_add_worksheet(workbook, NULL);

--- a/Common/Examples/DefaultExamples/Examples/HyperlinksExample.m
+++ b/Common/Examples/DefaultExamples/Examples/HyperlinksExample.m
@@ -32,7 +32,7 @@
      */
     
     /* Create a new workbook. */
-    lxw_workbook *workbook   = new_workbook([self.outputFilePath cStringUsingEncoding:NSUTF8StringEncoding]);
+    lxw_workbook *workbook   = new_workbook([self.outputFilePath fileSystemRepresentation]);
     
     /* Add a worksheet. */
     lxw_worksheet *worksheet = workbook_add_worksheet(workbook, NULL);

--- a/Common/Examples/DefaultExamples/Examples/MergeRangeExample.m
+++ b/Common/Examples/DefaultExamples/Examples/MergeRangeExample.m
@@ -31,7 +31,7 @@
      *
      */
     
-    lxw_workbook  *workbook     = new_workbook([self.outputFilePath cStringUsingEncoding:NSUTF8StringEncoding]);
+    lxw_workbook  *workbook     = new_workbook([self.outputFilePath fileSystemRepresentation]);
     lxw_worksheet *worksheet    = workbook_add_worksheet(workbook, NULL);
     lxw_format    *merge_format = workbook_add_format(workbook);
     

--- a/Common/Examples/DefaultExamples/Examples/PanesExample.m
+++ b/Common/Examples/DefaultExamples/Examples/PanesExample.m
@@ -36,7 +36,7 @@
 	int col;
 
 	/* Create a new workbook and add some worksheets. */
-	lxw_workbook  *workbook   = workbook_new([self.outputFilePath cStringUsingEncoding:NSUTF8StringEncoding]);
+	lxw_workbook  *workbook   = workbook_new([self.outputFilePath fileSystemRepresentation]);
 
 	lxw_worksheet *worksheet1 = workbook_add_worksheet(workbook, "Panes 1");
 	lxw_worksheet *worksheet2 = workbook_add_worksheet(workbook, "Panes 2");

--- a/Common/Examples/DefaultExamples/Examples/TabColorsExample.m
+++ b/Common/Examples/DefaultExamples/Examples/TabColorsExample.m
@@ -31,7 +31,7 @@
 	 *
 	 */
 
-	lxw_workbook  *workbook   = workbook_new([self.outputFilePath cStringUsingEncoding:NSUTF8StringEncoding]);
+	lxw_workbook  *workbook   = workbook_new([self.outputFilePath fileSystemRepresentation]);
 
 	/* Set up some worksheets. */
 	lxw_worksheet *worksheet1 = workbook_add_worksheet(workbook, NULL);

--- a/Common/Examples/DefaultExamples/Examples/Tutorial1Example.m
+++ b/Common/Examples/DefaultExamples/Examples/Tutorial1Example.m
@@ -48,7 +48,7 @@
     };
     
     /* Create a workbook and add a worksheet. */
-    lxw_workbook  *workbook  = new_workbook([self.outputFilePath cStringUsingEncoding:NSUTF8StringEncoding]);
+    lxw_workbook  *workbook  = new_workbook([self.outputFilePath fileSystemRepresentation]);
     lxw_worksheet *worksheet = workbook_add_worksheet(workbook, NULL);
     
     /* Start from the first cell. Rows and columns are zero indexed. */

--- a/Common/Examples/DefaultExamples/Examples/Tutorial2Example.m
+++ b/Common/Examples/DefaultExamples/Examples/Tutorial2Example.m
@@ -48,7 +48,7 @@
     };
     
     /* Create a workbook and add a worksheet. */
-    lxw_workbook  *workbook  = new_workbook([self.outputFilePath cStringUsingEncoding:NSUTF8StringEncoding]);
+    lxw_workbook  *workbook  = new_workbook([self.outputFilePath fileSystemRepresentation]);
     lxw_worksheet *worksheet = workbook_add_worksheet(workbook, NULL);
     int row = 0;
     int col = 0;

--- a/Common/Examples/DefaultExamples/Examples/Tutorial3Example.m
+++ b/Common/Examples/DefaultExamples/Examples/Tutorial3Example.m
@@ -49,7 +49,7 @@
     };
     
     /* Create a workbook and add a worksheet. */
-    lxw_workbook  *workbook  = new_workbook([self.outputFilePath cStringUsingEncoding:NSUTF8StringEncoding]);
+    lxw_workbook  *workbook  = new_workbook([self.outputFilePath fileSystemRepresentation]);
     lxw_worksheet *worksheet = workbook_add_worksheet(workbook, NULL);
     int row = 0;
     int col = 0;

--- a/Common/Examples/DefaultExamples/Examples/UTF8Example.m
+++ b/Common/Examples/DefaultExamples/Examples/UTF8Example.m
@@ -33,7 +33,7 @@
      *
      */
     
-    lxw_workbook  *workbook  = new_workbook([self.outputFilePath cStringUsingEncoding:NSUTF8StringEncoding]);
+    lxw_workbook  *workbook  = new_workbook([self.outputFilePath fileSystemRepresentation]);
     lxw_worksheet *worksheet = workbook_add_worksheet(workbook, NULL);
     
     worksheet_write_string(worksheet, 2, 1, "Это фраза на русском!", NULL);

--- a/Common/Examples/DefaultExamples/Examples/WorksheetProtectionExample.m
+++ b/Common/Examples/DefaultExamples/Examples/WorksheetProtectionExample.m
@@ -32,7 +32,7 @@
 	 *
 	 */
 
-	lxw_workbook  *workbook  = workbook_new([self.outputFilePath cStringUsingEncoding:NSUTF8StringEncoding]);
+	lxw_workbook  *workbook  = workbook_new([self.outputFilePath fileSystemRepresentation]);
 	lxw_worksheet *worksheet = workbook_add_worksheet(workbook, NULL);
 
 	lxw_format *unlocked = workbook_add_format(workbook);

--- a/libxlsxwriter-iOS-Swift/libxlsxwriter-Swift/SwiftAnatomyExample.swift
+++ b/libxlsxwriter-iOS-Swift/libxlsxwriter-Swift/SwiftAnatomyExample.swift
@@ -30,7 +30,7 @@ class SwiftAnatomyExample: Example {
         */
         
         // Create a new workbook.
-        let workbook = new_workbook((outputFilePath as NSString).UTF8String)
+        let workbook = new_workbook((outputFilePath as NSString).fileSystemRepresentation)
         
         // Add a worksheet with a user defined sheet name.
         let worksheet1 = workbook_add_worksheet(workbook, "Demo")


### PR DESCRIPTION
Normally, UTF8String would be better than “-cStringUsingEncoding:NSUTF8StringEncoding”. The problem is, that the file system layer on OS X (and iOS for that matter) requires a very specific Unicode representation. Only “-fileSystemRepresentation” is valid for producing this from NSString objects.
